### PR TITLE
Transfer the RealURL configuration in the site package

### DIFF
--- a/Configuration/System/realurl_conf.php
+++ b/Configuration/System/realurl_conf.php
@@ -1,0 +1,37 @@
+<?php
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'] = array (
+	'init' => array (
+		'appendMissingSlash' => 'ifNotFile,redirect[301]',
+		'respectSimulateStaticURLs' => true,
+		'enableCHashCache' => true,
+		'enableUrlDecodeCache' => false,
+		'enableUrlEncodeCache' => false,
+	),
+	'preVars' => array (
+		0 => array (
+			'GETvar' => 'L',
+			'valueMap' => array (
+				'en' => '2',
+			),
+			'noMatch' => 'bypass',
+		),
+	),
+	'pagePath' => array (
+		'type' => 'user',
+		'userFunc' => 'EXT:realurl/class.tx_realurl_advanced.php:&tx_realurl_advanced->main',
+		'spaceCharacter' => '-',
+		'languageGetVar' => 'L',
+		'rootpage_id' => '12',
+	),
+	'fixedPostVars' => array (
+		'xmlinclude' => array (
+			array(
+				'GETvar' => 'tx_xmlinclude_xmlinclude[URL]',
+				'userFunc' => 'EXT:xmlinclude/Classes/RealURL/tx_xmlinclude_realurl.php:&tx_xmlinclude_realurl->main'
+			)
+		),
+		'71' => 'xmlinclude',
+		'80' => 'xmlinclude',
+		'84' => 'xmlinclude',
+	),
+);


### PR DESCRIPTION
resolves AAC-97

After merging:
- The old file AddtionalConfiguration.php can be emptied
- in the TYPO3 backend (extension settings) refer to the file /typo3conf/ext/tmpl_fidaac/Configuration/System/realurl_conf.php
- delete the file setup/RealURL.txt in the fileadmin directory