### PR TITLE
Set the base URL as a variable.

### DIFF
--- a/Configuration/TypoScript/001_Config/Config.t3s
+++ b/Configuration/TypoScript/001_Config/Config.t3s
@@ -1,4 +1,11 @@
 // Global Settings
+# set base URL
+[globalString =_SERVER|HTTPS=on]
+    config.absRefPrefix = https://{$config.absRefPrefix}
+[else]
+    config.absRefPrefix = http://{$config.absRefPrefix}
+[global]
+
 config {
 	doctype = html5
 	renderCharset = utf-8
@@ -23,6 +30,8 @@ config {
 	linkVars = L(1-2)
 
 	tx_realurl_enable = 1
+	prefixLocalAnchors = all
+	absRelPath = /
 	# RealURL is incompatible with simulateStaticDocuments
 	simulateStaticDocuments = 0
 }
@@ -30,15 +39,3 @@ config {
 [globalVar = TSFE:id = 12]
   config.noPageTitle = 1
 [global]
-
-
-# set <base> URL
-[globalString =_SERVER|HTTPS=on]
-   config.baseURL = https
-[else]
-   config.baseURL = http
-[global]
-config.baseURL := appendString(://aac7.dev/)
-
-# besser moderner?
-#config.absRefPrefix = /


### PR DESCRIPTION
AAC-126

After Merging:
set the variable in the constants of the root page (config.absRefPrefix = yourdomain/)