### PR TITLE
Show content element tab in news elements to allow

### DIFF
--- a/Configuration/TSconfig/Permissions.t3s
+++ b/Configuration/TSconfig/Permissions.t3s
@@ -469,8 +469,9 @@
         author_email.disabled = 0
         datetime.disabled = 1
         archive.disabled = 0
+        bodytext.disabled = 0
         // Content Elements tab
-        content_elements.disabled = 1
+        content_elements.disabled = 0
         // Access tab
         # Publish Dates and Access Rights
         starttime.disabled = 0

--- a/Resources/Private/Templates/Extensions/News/Templates/News/Detail.html
+++ b/Resources/Private/Templates/Extensions/News/Templates/News/Detail.html
@@ -90,17 +90,18 @@
 			</div>
 			<n:renderMedia news="{newsItem}" imgClass="img-responsive" videoClass="video-wrapper" audioClass="audio-wrapper">
 
-				<f:if condition="{newsItem.contentElements}">
-					<!-- content elements -->
-					<f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
-				</f:if>
-
 				<f:render partial="Detail/MediaContainer" arguments="{media: newsItem.media, settings:settings}" />
 
 				<!-- main text -->
 				<div class="news-text-wrap" itemprop="articleBody">
 					<f:format.html>{newsItem.bodytext}</f:format.html>
 				</div>
+
+				<!-- content elements -->
+				<f:if condition="{newsItem.contentElements}">
+					<f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
+				</f:if>
+
 			</n:renderMedia>
 
 			<f:if condition="{settings.backPid}">


### PR DESCRIPTION
more than one image in news.
Change order of news content: body text and main image
should appear before additional content-element

Resolves AAC-785